### PR TITLE
Updated legal notice in footer.html

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -4,6 +4,6 @@
 		<a rel="license" href="https://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Lizenzvertrag" style="width:64px; border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under the <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International Lizenz</a>.
 		<br><br>
 		OpenGL Hardware Database - &copy; 2011-2023 by <a href="https://www.saschawillems.de/" target="blank">Sascha Willems</a><br>
-		OpenGL is a registered trademark and the OpenGL logo is a trademark of Silicon Graphics Inc.
+		OpenGL is a registered trademark and the OpenGL logo is a trademark of Hewlett Packard Enterprise used under license by Khronos.
 	</font>
 </p>


### PR DESCRIPTION
Silicon Graphics Inc. went bankrupt years ago and the trademarks are now owned by Hewlett Packard Enterprise instead.

See footer at: https://www.khronos.org/opengles/